### PR TITLE
Append to clouddriver.log

### DIFF
--- a/clouddriver-web/etc/init/clouddriver.conf
+++ b/clouddriver-web/etc/init/clouddriver.conf
@@ -6,4 +6,4 @@ expect fork
 
 stop on stopping spinnaker
 
-exec sudo -u spinnaker -g spinnaker /opt/clouddriver/bin/clouddriver 2>&1 > /var/log/spinnaker/clouddriver/clouddriver.log &
+exec sudo -u spinnaker -g spinnaker /opt/clouddriver/bin/clouddriver 2>&1 >> /var/log/spinnaker/clouddriver/clouddriver.log &


### PR DESCRIPTION
Append to clouddriver.log so that restarting clouddriver doesn't make the existing log lines disappear.
